### PR TITLE
Remove checker data for labplot and cfitsio

### DIFF
--- a/org.kde.labplot2.json
+++ b/org.kde.labplot2.json
@@ -78,13 +78,7 @@
                 {
                     "type": "archive",
                     "url": "http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.1.0.tar.gz",
-                    "sha256": "b367c695d2831958e7166921c3b356d5dfa51b1ecee505b97416ba39d1b6c17a",
-                    "x-checker-data": {
-                        "type": "html",
-                        "url": "http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/",
-                        "version-pattern": "cfitsio-([\\d\\.-]+)\\.tar\\.gz",
-                        "url-template": "http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-$version.tar.gz"
-                    }
+                    "sha256": "b367c695d2831958e7166921c3b356d5dfa51b1ecee505b97416ba39d1b6c17a"
                 }
             ]
         },
@@ -317,13 +311,7 @@
                 {
                     "type": "archive",
                     "url": "https://download.kde.org/stable/labplot/2.9.0/labplot-2.9.0-beta.tar.xz",
-                    "sha256": "876e403ac1aaadd614030fc1997018bbc73ebab04c080e3e1bcc81f404d3bc2f",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 1532,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/labplot/$version/labplot-$version.tar.xz"
-                    }
+                    "sha256": "876e403ac1aaadd614030fc1997018bbc73ebab04c080e3e1bcc81f404d3bc2f"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
- cfitsio seems to not go well with fedc
- labplot has been updated to beta, which isn't what the current checker data was expected to work with. While I can update checker data to use beta sources too, (as easy as removing `stable: true`), predicting filenames may get messy.