### PR TITLE
update deprecated boost url

### DIFF
--- a/org.kde.labplot2.json
+++ b/org.kde.labplot2.json
@@ -298,7 +298,7 @@
                                         "type": "anitya",
                                         "project-id": 6845,
                                         "stable-only": true,
-                                        "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                                        "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
                                     }
                                 }
                             ]


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
