### PR TITLE
End of life Rebase

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to org.kde.labplot.",
+  "end-of-life-rebase": "org.kde.labplot"
+}


### PR DESCRIPTION
New app id is org.kde.labplot. LabPlot 2 is comming to an end.